### PR TITLE
docs: tidy up cssGuide.md

### DIFF
--- a/doc/cssGuide.md
+++ b/doc/cssGuide.md
@@ -1,15 +1,13 @@
 # CSS Guide
 
-This guide will assume the usage of sass/scss.
-It is highly recommended to **not** use plain css.
-That said plain CSS is supported.
-If you need to quickly understand the different classes used,
-see the class reference at the bottom of this document.
+This guide assumes you use SASS/SCSS.
+We **don't recommend** that you use plain CSS.
+That said: plain CSS is supported.
 
-This guide will go over both the systems used,
-but also the recommended structure of the scss.
-The system is quite flexible,
-so you can structure things quite differently if you want to.
+If you need to quickly understand the different classes used, see the class reference at the bottom of this document.
+
+This guide will go over the systems used and the recommended structure of the SCSS.
+The system is quite flexible, so you can structure things quite differently if you want to.
 
 If you are writing a style for this project you have to follow the structure defined here.
 
@@ -18,17 +16,17 @@ If you are writing a style for this project you have to follow the structure def
 All classes have a common prefix.
 This is done in case this system is ever used as a part of a bigger documentation system.
 By default the prefix is `routedoc--`.
-Currently there are 2 values that should be changed in order to properly chnage the prefix:
+Currently there are 2 values that should be changed in order to properly change the prefix:
 
 - The `classPrefix` property in the config file.
-- The `$prefix` variable in `_variables.scss` (assuming you are using the default scss structure).
+- The `$prefix` variable in `_variables.scss` (assuming you are using the default SCSS structure).
 
-Classes used by the default html templates can be categorized in 2 different types:
+Classes used by the default HTML templates can be categorized in 2 different types:
 
 - Generic classes are used in multiple locations and represent a generic concept.
 - Specific classes are used once.
 
-Specific classes are structured a specifc way.
+Specific classes are structured in a specifc way.
 The start of a specific class is _always_ the parent class (if any).
 All segments are separated by 2 sequential dashes (`--`).
 
@@ -40,18 +38,18 @@ For example:
 > route--method
 > route--method--description
 
-## scss Rules
+## SCSS Rules
 
-It is recommended to use the following rules when writing scss:
+It is recommended to use the following rules when writing SCSS:
 
 - **Always** use `@use`, never use `@import`.
 - A variable called `$prefix` should exist.
   Every time the class prefix is used write something along the lines of `.#{$prefix}`.
-  Make sure to not include any selector tokens in the `$prefix` variable.
+  Do not include any selector tokens in the `$prefix` variable.
 
-## scss Structure
+## SCSS Structure
 
-scss files should be structured with the following files:
+SCSS files should be structured with the following files:
 
 ### style.scss
 
@@ -63,9 +61,9 @@ For example (`default` stylesheet):
 // Stylesheet created for `yaml-route-doc` (https://github.com/damymetzke/yaml-route-doc)
 // Author: Damy Metzke (damy.metzke@gmail.com)
 // Name: Default
-// Description: Default stylesheet meant to be functional and explainatory.
+// Description: Default stylesheet meant to be functional and explanatory.
 // Please use this as a starting point, or as a way to understand the class structure.
-// This is not meant for use in an end products.
+// This example is not intended for production.
 ```
 
 The author will always be the desired display name + email.
@@ -78,8 +76,8 @@ When determining variables keep the following in mind:
 - **All** colors should be defined as a variable.
 - Minimize the amount of 'base' colors.
   More complex colors should be derived from the base colors.
-  For example: you might have the base colors foreground, background and highlight.
-  From these colors the colors dark-highlight and light-highlight could be created.
+  For example: you might have the base colors `foreground`, `background` and `highlight`.
+  From these colors the colors `dark-highlight` and `light-highlight` could be created.
 - Almost all sizes based on px, em, etc. should be defined as a variable.
 - It is prefered to put variables in a map.
   Note that this is not always reasonable, make sure to think things through.
@@ -117,8 +115,7 @@ Using the `&` symbol it is now possible to use the correct classes with the pref
 }
 ```
 
-If you don't know how this works,
-basically `#{vars.$prefix}` will turn into `routedoc--` (if that is the defined prefix).
+If you don't know how this works, basically `#{vars.$prefix}` will turn into `routedoc--` (if that is the defined prefix).
 `&` will be replaced by its parent, which basically means the following:
 
 ```scss
@@ -140,10 +137,10 @@ basically `#{vars.$prefix}` will turn into `routedoc--` (if that is the defined 
 ```
 
 Specific classes have a recursive structure.
-Using similar techniques it is possible to move this recursion into a logical sass structure.
+Using similar techniques it is possible to move this recursion into a logical SASS structure.
 There are 3 rules to follow:
 
-- Every class with css properties exists.
+- Every class with CSS properties exists.
 - Every class which is the common ancestor of 2 other classes exists.
 - All classes are a child of their nearest existing parent.
 
@@ -178,12 +175,12 @@ For example, you could split `_specific.scss` in their respective types (group, 
 
 ### Generic
 
-| class    | meaning                                                                                     |
-| -------- | ------------------------------------------------------------------------------------------- |
-| card     | An object with a title (h*), and content (*). Can be any size and nesten inside other cards |
-| list     | A sequence of items which are always relatively short strings.                              |
-| array    | A sequence of content which are of any size, but never a small string.                      |
-| markdown | A block containing HTML which has been generated from markdown.                             |
+| class    | meaning                                                                                         |
+| -------- | ----------------------------------------------------------------------------------------------- |
+| card     | An object with a title (`h*`), and content (`*`). Can be any size and nested inside other cards |
+| list     | A sequence of items which are always relatively short strings.                                  |
+| array    | A sequence of content which can be of any size, but never a small string.                       |
+| markdown | A block containing HTML which has been generated from Markdown.                                 |
 
 ### Specific
 


### PR DESCRIPTION
- Use one sentence per line where possible
- Capitalize proper nouns like SCSS, CSS, HTML, etc.
- Use code blocks for some items
- Fix up bad styling of Markdown table caused by two unescaped * characters
- Fix some typos