### PR TITLE
docs: capitalize word CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ documenter.document("path/to/config.yml");
 
 ## More Documentation
 
-For more information about writing custom css please refer to the [CSS Guide](./doc/cssGuide.md)
+For more information about writing custom CSS please refer to the [CSS Guide](./doc/cssGuide.md)


### PR DESCRIPTION
## Changes:

- `css` -> `CSS`

## Context:

CSS is an abbreviation and so should be capitalized. 😉 